### PR TITLE
Feature/ssl elasticsearch

### DIFF
--- a/nodejs/config.js
+++ b/nodejs/config.js
@@ -8,6 +8,8 @@ module.exports = {
   LogLevel: process.env.LogLevel || "warn",
   Port: process.env.PORT || 9000,
   ElasticSearchHost: process.env.ElasticSearchHost || "https://search-csp-server-********.****region****.es.amazonaws.com",
+  ElasticSearchSSLCA: process.env.ElasticSearchSSLCA || "",
+  ElasticSearchSSLStrict: process.env.ElasticSearchSSLStrict || false,
   ElasticSearchVersion: process.env.ElasticSearchVersion || "master",
   ElasticSearchIndex: process.env.ElasticSearchIndex || "cspdata"
 };

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -1,13 +1,23 @@
 'use strict';
 
 var restify = require('restify'),
-  async = require('async');
+  async = require('async'),
+  fs = require('fs');
 
 module.exports = function(config, elasticsearch) {
-  var elasticClient;
+  var elasticClient, es_SSL = {};
+
+  // enable SSL CA verification when contacting elasticSearch
+  if(config.ElasticSearchSSLCA) {
+    es_SSL = {
+      ca: fs.readFileSync(config.ElasticSearchSSLCA),
+      rejectUnauthorized: config.ElasticSearchSSLStrict
+    }
+  }
 
   elasticClient = new elasticsearch.Client({
     host: config.ElasticSearchHost,
+    ssl: es_SSL,
 //    log: 'trace',
     log: 'error',
 //    log: 'info;',


### PR DESCRIPTION
Adding support for CA verification when contacting elasticSearch

- ElasticSearchSSLCA will have to contain path to CA file
- ElasticSearchSSLStrict defines if we should be strict (e.g. accept self signed certificates)
- Not sure if require('fs') is OK where it is or if you want it to be inside the if condition